### PR TITLE
FC-1041 remove "docs" from select handler

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -18,9 +18,6 @@ class Sidebar extends React.Component {
 
   handleSelect(selected) {
     selected = selected || {};
-    if (selected === "docs") {
-      window.open("https://docs.flur.ee/", "_blank");
-    }
     if (selected.db) {
       this.props._db.changeDatabase(selected.db);
     }


### PR DESCRIPTION
Removed "Docs"-related code from select handler section since both references are (now) handled by anchors/links