### PR TITLE
Make ledger naming example a valid network/ledger name

### DIFF
--- a/src/screens/Account.jsx
+++ b/src/screens/Account.jsx
@@ -111,13 +111,13 @@ export class NewDatabaseModal extends Component {
               <p>
                 <b>Note:</b> A Ledger Id uniquely identifies a ledger within a
                 network. A Ledger Id begins with the network name (e.g
-                myNetwork) followed by a forward slash "/" and the Ledger name
-                (e.g myLedger).
+                my-network) followed by a forward slash "/" and the Ledger name
+                (e.g my-ledger).
                 <br></br>
               </p>
               <p>
                 <em>
-                  <b>A Ledger Id example:</b> myNetwork/myLedger
+                  <b>A Ledger Id example:</b> my-network/my-ledger
                 </em>
               </p>
               <Form onSubmit={this.onGenerate.bind(this)}>

--- a/src/screens/Account.jsx
+++ b/src/screens/Account.jsx
@@ -112,7 +112,7 @@ export class NewDatabaseModal extends Component {
                 <b>Note:</b> A Ledger Id uniquely identifies a ledger within a
                 network. A Ledger Id begins with the network name (e.g
                 my-network) followed by a forward slash "/" and the Ledger name
-                (e.g my-ledger).
+                (e.g my-ledger). Only lower-case letters, numbers, and hyphens (-) are aloud.
                 <br></br>
               </p>
               <p>


### PR DESCRIPTION
Current example network/ledger name in Create Ledger modal is an invalid name. This updates the network and ledger names to valid values that can be used to create a ledger. Also adds a sentence denoting the allowed characters for a ledger name.